### PR TITLE
Remove support for Node.js v18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x, 25.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
 
     services:
       postgres:


### PR DESCRIPTION
The latest versions of vitest don't support it.