### PR TITLE
Fix up "replace" option

### DIFF
--- a/packages/api/src/items.ts
+++ b/packages/api/src/items.ts
@@ -106,7 +106,7 @@ const mapItemFromDatabase = (row: DatabaseItem, labels: string[] = []): ItemWith
 }
 
 const addItemRequestSchema = z.object({
-  replace: z.coerce.boolean().optional()
+  replace: z.string().optional()
 })
 
 const addItemBodySchema = z.object({
@@ -129,7 +129,7 @@ export const addItem = async (params: ParsedQs, itemData: unknown): Promise<Item
   const parsedParams = addItemRequestSchema.parse(params)
   const parsedItemData = addItemBodySchema.parse(itemData)
   const db = getDatabaseConnection()
-  if (parsedParams.replace ?? false) {
+  if (parsedParams.replace === 'true') {
     // Delete rather than mark deleted_at so as to not interfere with getNextItem()
     await db('items').where({
       title: parsedItemData.title,

--- a/packages/api/src/migrations/0007-item-labels-cascade.ts
+++ b/packages/api/src/migrations/0007-item-labels-cascade.ts
@@ -1,0 +1,53 @@
+/* c8 ignore start */
+import knex from 'knex'
+
+const upSql = `
+BEGIN;
+
+ALTER TABLE item_labels
+DROP CONSTRAINT item_labels_item_id_fkey;
+
+ALTER TABLE item_labels
+ADD CONSTRAINT item_labels_item_id_fkey
+FOREIGN KEY (item_id) REFERENCES public.items (id) MATCH SIMPLE
+ON UPDATE NO ACTION
+ON DELETE CASCADE;
+
+ALTER TABLE item_labels
+DROP CONSTRAINT item_labels_label_id_fkey;
+
+ALTER TABLE item_labels
+ADD CONSTRAINT item_labels_label_id_fkey
+FOREIGN KEY (label_id) REFERENCES public.labels (id) MATCH SIMPLE
+ON UPDATE NO ACTION
+ON DELETE CASCADE;
+
+COMMIT;
+`
+
+const downSql = `
+BEGIN;
+
+ALTER TABLE item_labels
+DROP CONSTRAINT item_labels_item_id_fkey;
+
+ALTER TABLE item_labels
+ADD CONSTRAINT item_labels_item_id_fkey
+FOREIGN KEY (item_id) REFERENCES public.items (id) MATCH SIMPLE
+ON UPDATE NO ACTION
+ON DELETE NO ACTION;
+
+ALTER TABLE item_labels
+DROP CONSTRAINT item_labels_label_id_fkey;
+
+ALTER TABLE item_labels
+ADD CONSTRAINT item_labels_label_id_fkey
+FOREIGN KEY (label_id) REFERENCES public.labels (id) MATCH SIMPLE
+ON UPDATE NO ACTION
+ON DELETE NO ACTION;
+
+COMMIT;
+`
+
+export const up = (knex: knex.Knex): knex.Knex.SchemaBuilder => knex.schema.raw(upSql)
+export const down = (knex: knex.Knex): knex.Knex.SchemaBuilder => knex.schema.raw(downSql)

--- a/packages/api/test/e2e/add-item.spec.ts
+++ b/packages/api/test/e2e/add-item.spec.ts
@@ -116,7 +116,7 @@ describe('POST /items', () => {
       })
   })
 
-  it('should delete existing items with the same name when "replace" parameter is true', async () => {
+  it('should delete existing items with the same name when "replace" parameter is "true"', async () => {
     const testItem1 = {
       id: 'bdb76fb4-98aa-4b48-bb9c-fc647199e09f',
       title: 'Test Item',
@@ -153,10 +153,13 @@ describe('POST /items', () => {
     await db('items').insert(testItem1)
     await db('items').insert(testItem2)
     await db('items').insert(testItem3)
+    await db('item_labels').insert({ item_id: testItem1.id, label_id: 'busywork' })
+    await db('item_labels').insert({ item_id: testItem2.id, label_id: 'urgent' })
+    await db('item_labels').insert({ item_id: testItem3.id, label_id: 'trivial' })
 
     await request(app)
       .post('/items')
-      .query({ replace: 1 })
+      .query({ replace: 'true' })
       .send({
         author: 'John Doe',
         due: '2024-06-01T10:00:00.000Z',
@@ -176,6 +179,74 @@ describe('POST /items', () => {
 
     const testItems = await db('items').where({ title: 'Test Item' })
     expect(testItems).toHaveLength(1)
+
+    const nonTestItems = await db('items').whereNot({ title: 'Test Item' })
+    expect(nonTestItems).toHaveLength(1)
+  })
+
+  it('should NOT delete existing items with the same name when "replace" parameter is NOT "true"', async () => {
+    const testItem1 = {
+      id: 'bdb76fb4-98aa-4b48-bb9c-fc647199e09f',
+      title: 'Test Item',
+      uri: 'http://example.com',
+      type_id: 'task',
+      length: 10,
+      due: '2024-06-01T00:00:00.000Z',
+      created_at: new Date('2024-05-31T00:00:00.000Z'),
+      updated_at: new Date('2024-05-31T00:00:00.000Z'),
+      deleted_at: null
+    }
+    const testItem2 = {
+      id: '2400b74e-3d59-4fcc-9d5f-3a0ad46a2066',
+      title: 'Test Item',
+      uri: 'http://example.com/foo',
+      type_id: 'task',
+      length: 30,
+      due: '2024-06-01T00:00:00.000Z',
+      created_at: new Date('2024-05-31T00:00:00.000Z'),
+      updated_at: new Date('2024-05-31T00:00:00.000Z'),
+      deleted_at: null
+    }
+    const testItem3 = {
+      id: '440c6edb-0489-4a51-bd51-5c301be888f7',
+      title: 'Other Item',
+      uri: 'http://example.com/bar',
+      type_id: 'task',
+      length: 10,
+      due: '2024-06-01T00:00:00.000Z',
+      created_at: new Date('2024-05-31T00:00:00.000Z'),
+      updated_at: new Date('2024-05-31T00:00:00.000Z'),
+      deleted_at: null
+    }
+    await db('items').insert(testItem1)
+    await db('items').insert(testItem2)
+    await db('items').insert(testItem3)
+    await db('item_labels').insert({ item_id: testItem1.id, label_id: 'busywork' })
+    await db('item_labels').insert({ item_id: testItem2.id, label_id: 'urgent' })
+    await db('item_labels').insert({ item_id: testItem3.id, label_id: 'trivial' })
+
+    await request(app)
+      .post('/items')
+      .query({ replace: 'false' })
+      .send({
+        author: 'John Doe',
+        due: '2024-06-01T10:00:00.000Z',
+        expectedRank: 1,
+        imageUri: 'http://example.com/image.jpg',
+        labels: ['work', 'urgent'],
+        language: 'en',
+        length: 100,
+        rank: 5,
+        rating: 4.5,
+        summary: 'This is a summary.',
+        title: 'Test Item',
+        uri: 'http://example.com',
+        type: 'task'
+      })
+      .expect(201)
+
+    const testItems = await db('items').where({ title: 'Test Item' })
+    expect(testItems).toHaveLength(3)
 
     const nonTestItems = await db('items').whereNot({ title: 'Test Item' })
     expect(nonTestItems).toHaveLength(1)


### PR DESCRIPTION
* Make `replace` param a string that must have value of `true` to replace items, to prevent coercion confusion. Add test to confirm that non-`true` value doesn't delete anything.
* Auto-delete item labels when the label or item is deleted. Update tests to check for this.
